### PR TITLE
Update Ace, remove Tab indent, improve code preferences (scopes under the gear icon)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val requirejs        = "org.webjars" % "requirejs" % "2.1.11"
   val jquery           = "org.webjars" % "jquery" % "2.0.3"
   val knockout         = "org.webjars" % "knockout" % "3.0.0"
-  val ace              = "org.webjars" % "ace" % "1.1.3"
+  val ace              = "org.webjars" % "ace" % "1.1.7-1"
   val keymage          = "org.webjars" % "keymage" % "1.0.1"
 
   // Analyzers used by Inspect

--- a/ui/app/assets/plugins/code/code.html
+++ b/ui/app/assets/plugins/code/code.html
@@ -33,22 +33,6 @@
               <select data-bind="options: editor.fontSizes, value: editor.chosenFontSize"></select>
               </label>
             </p>
-
-            <!-- ko if: selectedDocument -->
-            <p>
-              <label>
-                <input type="checkbox" data-bind="checked: selectedDocument().chosenSoftTabs">
-                Use soft tabs
-              </label>
-            </p>
-            <p>
-              <label>
-                Tab size
-                <select data-bind="options: selectedDocument().tabSizes, value: selectedDocument().chosenTabSize"></select>
-              </label>
-            </p>
-            <!-- /ko -->
-
           </dd>
         </dl>
         <ul class="tabs" data-bind="foreach: openedDocuments">

--- a/ui/app/assets/plugins/code/code.html
+++ b/ui/app/assets/plugins/code/code.html
@@ -13,10 +13,42 @@
       <header>
         <dl class="code-options dropdown">
           <dt><svg data-bind="svg: '/assets/icons/gear-mini.svg'"/></dt>
-          <dd>
+          <dd class="prevent">
             <a data-bind="click: closeAll">Close all</a>
             <a data-bind="click: saveAll">Save all</a>
-            <label><input type="checkbox" data-bind="checked: autoSave"> Auto-save</label>
+
+            <p>
+              <label><input type="checkbox" data-bind="checked: autoSave"> Auto-save</label>
+            </p>
+
+            <p>
+              <label>
+                Theme:
+                <select data-bind="options: editor.themes, value: editor.chosenTheme"></select>
+              </label>
+            </p>
+            <p>
+              <label>
+              Font size
+              <select data-bind="options: editor.fontSizes, value: editor.chosenFontSize"></select>
+              </label>
+            </p>
+
+            <!-- ko if: selectedDocument -->
+            <p>
+              <label>
+                <input type="checkbox" data-bind="checked: selectedDocument().chosenSoftTabs">
+                Use soft tabs
+              </label>
+            </p>
+            <p>
+              <label>
+                Tab size
+                <select data-bind="options: selectedDocument().tabSizes, value: selectedDocument().chosenTabSize"></select>
+              </label>
+            </p>
+            <!-- /ko -->
+
           </dd>
         </dl>
         <ul class="tabs" data-bind="foreach: openedDocuments">

--- a/ui/app/assets/plugins/code/code.less
+++ b/ui/app/assets/plugins/code/code.less
@@ -31,9 +31,15 @@
     .align-self(center);
     dd {
       background: #fff;
-      min-width: 120px;
+      min-width: 230px;
       padding: 5px 0;
       border-radius: 3px;
+      p {
+        margin: 5px 0;
+      }
+      select {
+        max-width: 120px;
+      }
     }
     dt svg {
       margin: 2px 4px;

--- a/ui/app/assets/plugins/code/document.js
+++ b/ui/app/assets/plugins/code/document.js
@@ -82,18 +82,6 @@ define([
     }
     self.revert(); // Getting the server version right away
 
-    // Formatting:
-    self.chosenSoftTabs = ko.observable(true);
-    ko.doOnChange(self.chosenSoftTabs, function(t) {
-      self.session.setUseSoftTabs(t);
-    });
-
-    self.tabSizes = [1,2,3,4,8];
-    self.chosenTabSize = ko.observable(2);
-    ko.doOnChange(self.chosenTabSize, function(t) {
-      self.session.setTabSize(t);
-    });
-
     // Right click on the tab
     self.contextmenu = {
       'Save':     self.save.bind(self),

--- a/ui/app/assets/widgets/editor/editor.html
+++ b/ui/app/assets/widgets/editor/editor.html
@@ -1,19 +1,7 @@
 <div class="documentWrapper">
   <!-- ko if: selectedDocument -->
   <footer>
-    <span data-bnd="text: location"></span>
-    <span>Theme:
-      <select data-bind="options: themes, value: chosenTheme"></select>
-    </span>
-    <span>Font size
-      <select data-bind="options: fontSizes, value: chosenFontSize"></select>
-    </span>
-    <span>
-      <label><input type="checkbox" data-bind="checked: selectedDocument().chosenSoftTabs">Use soft tabs</label>
-    </span>
-    <span>Tab size
-      <select data-bind="options: selectedDocument().tabSizes, value: selectedDocument().chosenTabSize"></select>
-    </span>
+    <span data-bind="text: selectedDocument().location"></span>
   </footer>
   <div class="editor">
     <!-- ko include: editorContainer --><!-- /ko -->

--- a/ui/app/assets/widgets/editor/editor.js
+++ b/ui/app/assets/widgets/editor/editor.js
@@ -86,6 +86,12 @@ define([
   }
 
   return {
+    themes: Object.keys(themes),
+    chosenTheme: chosenTheme,
+    fontSizes: Object.keys(fontSizes),
+    chosenFontSize: chosenFontSize,
+    editorContainer: editor.container,
+
     setDocument: function(selectedDocument) {
       State.selectedDocument = selectedDocument;
       // bind the document


### PR DESCRIPTION
![screen shot 2014-12-22 at 14 52 31](https://cloud.githubusercontent.com/assets/197573/5525688/36df2024-89ea-11e4-8301-6f98b7d9349b.png)

@henrikengstrom BTW, the tab behaviour does work as I told you: it doesn't update indentation, but sets it for new lines. My opinion is: we keep it as is. Who votes for removing the functionality?