### PR TITLE
Moves Activator to the latest sbt version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  val sbtVersion = "0.13.6"
-  val sbtLibraryVersion = "0.13.6" // for sbtIO on scala 2.11
+  val sbtVersion = "0.13.7"
+  val sbtLibraryVersion = "0.13.7" // for sbtIO on scala 2.11
 
   val sbtPluginVersion = "0.13"
   val sbtPluginScalaVersion = "2.11.4"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/ui/app/assets/plugins/monitoring/newrelic/newrelic.html
+++ b/ui/app/assets/plugins/monitoring/newrelic/newrelic.html
@@ -61,9 +61,9 @@
 
     </div>
     <div class="tabs-step configure" data-bind="css: { opened: selectedTab() == 'configure' }">
-      <h2>Enter Licence Key</h2>
-      <p>To get your licence key, you must <a href="https://www.newrelic.com/typesafe" target="_blank">Sign Up</a> or <a href="https://rpm.newrelic.com/" target="_blank">Login</a> to a New Relic account.</p>
-      <p>Thereafter your licence key is available in the application setup screen (<a href="/public/plugins/monitoring/newrelic/LicenseKey.png" target="_blank">see this screenshot</a>)</p>
+      <h2>Enter License Key</h2>
+      <p>To get your license key, you must <a href="https://www.newrelic.com/typesafe" target="_blank">Sign Up</a> or <a href="https://rpm.newrelic.com/" target="_blank">Login</a> to a New Relic account.</p>
+      <p>Thereafter your license key is available in the application setup screen (<a href="/public/plugins/monitoring/newrelic/LicenseKey.png" target="_blank">see this screenshot</a>)</p>
       <p>
         <input type="text" id="licenseKey" data-bind="value: tempLicenseKey, valueUpdate: 'input'"/>
         <button class="button" data-bind="click: saveLicenseKey">Save</button>

--- a/ui/app/assets/widgets/home/home.js
+++ b/ui/app/assets/widgets/home/home.js
@@ -2,29 +2,39 @@
  Copyright (C) 2014 Typesafe, Inc <http://typesafe.com>
  */
 define([
+  "commons/websocket",
   './open/open',
   './templates/templates',
   './working/working',
   // 'css!./home'
 ],function(
+  websocket,
   open,
   templates,
   working
 ) {
 
+  var stream = websocket.subscribe('subType', 'BuildFailedToLoad');
+  stream.map(function (e) {
+    window.alert('Could not load project.\n' +
+    'If you are creating Typesafe Reactive Platform project you must add a \'typesafe.propertied\' file in the \'<template>/project\' folder.\n' +
+    'The file must contain your subscription id in the following format \'typesafe.subscription=<YOUR ID>\'\n' +
+    'For more information see: http://typesafe.com/subscription');
+  });
+
   var SharedState = {
     working: ko.observable(false)
-  }
+  };
 
   var State = {
     open: open.render(SharedState),
     templates: templates.render(SharedState),
     working: working.render(SharedState)
-  }
+  };
 
   return {
     render: function() {
       ko.applyBindings(State);
     }
   }
-})
+});

--- a/ui/app/assets/widgets/home/templates/templates.js
+++ b/ui/app/assets/widgets/home/templates/templates.js
@@ -14,7 +14,7 @@ define([
   tpl
 ) {
 
-  var trpInfoSeen = settings.observable("reactive-platform.accepted-licence", false);
+  var trpInfoSeen = settings.observable("reactive-platform.accepted-license", false);
 
   // Memorise last used directory
   var lastFolder = settings.observable("last-folder", window.homeFolder);

--- a/ui/app/assets/widgets/home/working/working.html
+++ b/ui/app/assets/widgets/home/working/working.html
@@ -2,7 +2,7 @@
   <header>
     <h2>Your application is being opened</h2>
   </header>
-  <article>
+  <article style="overflow: scroll">
     <p>This will just take a minute...</p>
     <ul class="logs" id="loading-logs"></ul>
   </article>

--- a/ui/app/snap/AppManager.scala
+++ b/ui/app/snap/AppManager.scala
@@ -300,12 +300,14 @@ object AppManager {
 
           val eventsSub = client.handleEvents({ event =>
             import sbt.protocol._
+
             val json = event match {
               case log: LogEvent => log match {
                 case e: TaskLogEvent => SbtProtocol.wrapEvent(e)
                 case e: CoreLogEvent => SbtProtocol.wrapEvent(e)
                 case e: BackgroundJobLogEvent => SbtProtocol.wrapEvent(e)
               }
+              case e: BuildFailedToLoad => SbtProtocol.wrapEvent(e)
               case _ =>
                 SbtProtocol.synthesizeLogEvent(LogMessage.DEBUG, event.toString)
             }


### PR DESCRIPTION
We need 0.13.7 of sbt as this is required by TRP.

Also adds load failure detection of project. 
This could need some UI love by @Warry.
Right now there is a pop-up fired up when a build failure is detected. A better variant would probably be to use a modal window with which we can do more things like reload into the home start page when the user clicks a button, link to the Typesafe subscription page, explain in detail how to set things up.

This is _not_ a generic solution for when the project fails to load as it is only warning about TRP projects loaded. We can always add information to the ``BuildFailedToLoad`` event with why the project did not load. This is a starting point that at least does _something_ to explain what is going on.