### PR TITLE
Mark opened files as dirty if parent folder or file itself was renamed

### DIFF
--- a/ui/app/assets/plugins/code/code.js
+++ b/ui/app/assets/plugins/code/code.js
@@ -151,6 +151,28 @@ define([
     });
   });
 
+  // Rename / Delete events :
+  browser.browserEvent.subscribe(function(e) {
+    switch(e.type){
+      case "renameFolder":
+      case "deleteFolder":
+        openedDocuments().forEach(function(doc) {
+          if (doc.location.indexOf(e.folder.location) === 0){
+            doc.edited(true);
+          }
+        });
+        break;
+      case "renameFile":
+      case "deleteFile":
+        openedDocuments().forEach(function(doc) {
+          if (doc.location === e.file.location){
+            doc.edited(true);
+          }
+        });
+        break;
+    }
+  });
+
   var State = {
     browser: browser,
     editor: editor,


### PR DESCRIPTION
I cannot easily track the change on the particular file, because it would require to change a lot of static / immutable / working things to become async and observable (such as: type of the file, syntax highlighting...). So just showing it as dirty, like mot text editors.