### PR TITLE
update to identify TaskSuccess by $type

### DIFF
--- a/ui/app/assets/services/sbt/tasks.js
+++ b/ui/app/assets/services/sbt/tasks.js
@@ -401,7 +401,7 @@ define([
 
   var valueChanged = subTypeEventStream("ValueChanged").map(function(message) {
     var valueOrNull = null;
-    if (message.event.value.success)
+    if (message.event.value.$type.indexOf("Success") >= 0)
       valueOrNull = message.event.value;
     debug && console.log("ValueChanged for ", message.event.key.key.name, valueOrNull, message.event);
     return {


### PR DESCRIPTION
There's no longer a boolean "success" field, which is sort
of ugly in JS but avoids a special case in Scala