### PR TITLE
Show active task even if it isn't a known one

### DIFF
--- a/ui/app/assets/services/sbt/events.js
+++ b/ui/app/assets/services/sbt/events.js
@@ -57,8 +57,11 @@ define([
       return { id: "activity", label: "Testing project", url: "#build/test" }
     } else if(tasks.workingTasks.run()){
       return { id: "activity", label: "Running project", url: "#build/run" }
+    } else if(tasks.workingTasks.current()) {
+      var current = tasks.workingTasks.current();
+      return { id: "activity", label: "Running '" + current.command + "'" , url: "#build/tasks" };
     } else {
-      return { id: "ok", label: "Activator is running smoothly", url: "#build/tasks" }
+      return { id: "ok", label: "No errors or activity right now", url: "#build/tasks" };
     }
   });
 

--- a/ui/app/assets/services/sbt/tasks.js
+++ b/ui/app/assets/services/sbt/tasks.js
@@ -37,15 +37,18 @@ define([
   Tasks status
   */
   var workingTasks = {
+    // these three are just flags (are they running)
     compile:  ko.observable(false),
     run:      ko.observable(false),
-    test:     ko.observable(false)
-  }
+    test:     ko.observable(false),
+    // this one is the Execution object or null
+    current:  ko.observable(null)
+  };
   var pendingTasks = {
     compile:  ko.observable(false),
     run:      ko.observable(false),
     test:     ko.observable(false)
-  }
+  };
 
   /**
   Stream Events
@@ -290,6 +293,8 @@ define([
     var execution = executionsById[message.event.id];
     if (execution) {
       execution.started(new Date());
+      workingTasks.current(execution);
+
       // Increment active tasks (to make icons glowing)
       switch(execution.commandId){
         case "compile":
@@ -325,6 +330,11 @@ define([
     execution.succeeded(succeeded);
     taskComplete(execution.commandId, succeeded); // Throw an event
     execution.finished(new Date());
+
+    var current = workingTasks.current();
+    if (current !== null && current.executionId === execution.executionId) {
+      workingTasks.current(null);
+    }
 
     // Decrement active tasks (to stop icons glowing if no pending task ;; if counter is 0)
     switch(execution.commandId){


### PR DESCRIPTION
This makes things feel a lot nicer if I type "update"
or something like that in the search box.

Also, clarified "Activator is running smoothly" to
"no errors or activity right now" which I think makes
more sense. The issue is whether the app has errors,
not how activator is.