### PR TITLE
Change when/how we clear out errors and test results

### DIFF
--- a/ui/app/assets/plugins/build/tasks/tasks.html
+++ b/ui/app/assets/plugins/build/tasks/tasks.html
@@ -14,21 +14,21 @@
             <td class="command" data-bind="text: command"></td>
             <td class="data">
             <!-- ko if: finished() -->
-              <!-- ko if: compilationErrors.length && (compilationErrors[0].severity === "Error") -->
+              <!-- ko if: compilationErrors().length && (compilationErrors()[0].severity === "Error") -->
               <span class="compilationErrors">
-                <span class="compilationErrorsNumber" data-bind="text: compilationErrors.length"></span>
+                <span class="compilationErrorsNumber" data-bind="text: compilationErrors().length"></span>
                 compilation error(s)
               </span>
               <!-- /ko -->
-              <!-- ko if: compilationErrors.length && (compilationErrors[0].severity === "Warn") -->
+              <!-- ko if: compilationErrors().length && (compilationErrors()[0].severity === "Warn") -->
               <span class="compilationErrors">
-                <span class="compilationErrorsNumber" data-bind="text: compilationErrors.length"></span>
+                <span class="compilationErrorsNumber" data-bind="text: compilationErrors().length"></span>
                 compilation warning(s)
               </span>
               <!-- /ko -->
               <!-- ko if: testResults.length -->
               <span class="testResults">
-                <span class="testResultsNumber" data-bind="text: testResults.filter(function(t){ return t.outcome == 'passed'}).length"></span>/<span class="testResultsNumber" data-bind="text: testResults.length"></span>
+                <span class="testResultsNumber" data-bind="text: testResults.filter(function(t){ return t.outcome == 'passed'}).length"></span>/<span class="testResultsNumber" data-bind="text: testResults().length"></span>
                 test(s) passed
               </span>
               <!-- /ko -->

--- a/ui/app/assets/services/sbt/events.js
+++ b/ui/app/assets/services/sbt/events.js
@@ -85,8 +85,8 @@ define([
           notifications.unshift(new Notification("Test failed", "#test/results", "test", execution));
         }
       } else if (router.current().id !== "build"){
-        if (execution.compilationErrors.length && execution.compilationErrors[0].position){
-          var url = "#code"+ fs.relative(execution.compilationErrors[0].position.sourcePath)+":"+execution.compilationErrors[0].position.line;
+        if (execution.compilationErrors().length && execution.compilationErrors()[0].position){
+          var url = "#code"+ fs.relative(execution.compilationErrors()[0].position.sourcePath)+":"+execution.compilationErrors()[0].position.line;
           notifications.unshift(new Notification("Compilation error", url, "code", execution));
         } else {
           notifications.unshift(new Notification("Build error", "#build/tasks/"+execution.executionId, "build", execution));
@@ -118,16 +118,20 @@ define([
   */
   tasks.ProcessedExecutionsStream.each(function(execution) {
     // Update Tests counters
-    if (execution.testResults){
-      errorCounters.test(execution.testResults.filter(function(t) {
+    // TODO errorCounters.test can just be a ko.computed from tasks.testResults
+    if (execution.testResults().length > 0){
+      errorCounters.test(execution.testResults().filter(function(t) {
         return t.outcome === "failed";
       }).length);
     }
 
     // Update Compile/Code counter
-    errorCounters.code(execution.compilationErrors.filter(function(m) {
-      return m.severity === "Error" || m.severity === "Warn";
-    }).length);
+    // TODO errorCounters.code can just be a ko.computed from tasks.compilationErrors
+    if (execution.changedCompileResult) {
+      errorCounters.code(execution.compilationErrors().filter(function(m) {
+        return m.severity === "Error" || m.severity === "Warn";
+      }).length);
+    }
 
     // Run auto-commands
     if (execution.succeeded() && execution.command === "compile") {

--- a/ui/app/snap/SbtClientActor.scala
+++ b/ui/app/snap/SbtClientActor.scala
@@ -153,7 +153,7 @@ class SbtClientLifeCycleHandlerActor(val client: SbtClient) extends Actor with A
           }
 
       val lazySubs: Seq[Subscription] =
-        Seq("compileIncremental") map { name =>
+        Seq[String]() map { name =>
           client.rawLazyWatch(name)(forward)
         }
 


### PR DESCRIPTION
Previously, if you did a compile and then some unrelated task,
we would clear out your errors. Instead, track whenever a compileIncremental
result changes (which could be part of some other task), and when it does
the errors from the execution in progress will "take over" as the current
errors.

Also, always prefer errors and tests from the execution in progress
over errors from prior ones; this means that errors will stream in,
rather than all showing up at the end.

This introduces an error log message about "can't serialize the result of compileIncremental," so I have to go remove that println from sbt-remote-control I think. but we don't have to block on that. 