### PR TITLE
Forward DetachedEvent to JavaScript

### DIFF
--- a/ui/app/snap/SbtClientActor.scala
+++ b/ui/app/snap/SbtClientActor.scala
@@ -51,6 +51,7 @@ class SbtClientActor(val client: SbtClient) extends Actor with ActorLogging {
       case finished: TaskFinished => forwardOverSocket(finished)
       case started: TaskStarted => forwardOverSocket(started)
       case taskEvent: TaskEvent => forwardOverSocket(taskEvent)
+      case detachedEvent: DetachedEvent => forwardOverSocket(detachedEvent)
       case loaded: BuildLoaded => forwardOverSocket(loaded)
       case failed: BuildFailedToLoad => forwardOverSocket(failed)
       case background: BackgroundJobEvent => forwardOverSocket(background)


### PR DESCRIPTION
This has no practical effect for now except to prevent a MatchError,
but will be needed to get RP events later.