### PR TITLE
Don't show debug logs when opening a new project

### DIFF
--- a/ui/app/assets/widgets/home/working/working.js
+++ b/ui/app/assets/widgets/home/working/working.js
@@ -25,10 +25,12 @@ define([
   }
 
   websocket.subscribe({type: "sbt", subType: "DetachedLogEvent"}).fork().each(function(message) {
-    logs.push({
-      message: message.event.entry.message,
-      type: "info"
-    });
+    if (message.event.entry.level !== "debug") {
+      logs.push({
+        message: message.event.entry.message,
+        type: "info"
+      });
+    }
   });
 
   websocket.subscribe({ response: String }).fork().each(function(message) {


### PR DESCRIPTION
The log view here isn't scalable, and debug logs for ivy
resolution are ~15k lines vs ~500 lines for non-debug.
This makes things several times faster.