### PR TITLE
Automate syncing the sbt-echo version with our build

### DIFF
--- a/project/buildinfo.sbt
+++ b/project/buildinfo.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")

--- a/project/sbtEcho.scala
+++ b/project/sbtEcho.scala
@@ -3,6 +3,7 @@ import sbt.Keys._
 import com.typesafe.sbt.SbtGit
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import sbtbuildinfo.Plugin._
 
 object SbtEchoBuild extends Build {
   def baseVersions: Seq[Setting[_]] = SbtGit.versionWithGit
@@ -11,6 +12,7 @@ object SbtEchoBuild extends Build {
     Project("sbt-echo", base = file("sbt-echo"))
       settings (noPublishSettings: _*)
       settings (defaultSettings: _*)
+      settings (version := Dependencies.echoPluginVersion)
       aggregate(sbtEchoAkka, sbtEchoPlay)
     )
 
@@ -37,12 +39,20 @@ object SbtEchoBuild extends Build {
     publishLocal := {}
   )
 
+  val aspectJVersion = taskKey[String]("aspectj version to go in buildinfo")
+
   lazy val sbtEchoAkka = (
     Project("sbt-echo-akka", file("sbt-echo/akka"))
       settings (defaultSettings: _*)
+      settings (buildInfoSettings: _*)
       settings(
       name := "sbt-echo",
-      libraryDependencies ++= Seq(Dependencies.aspectjTools, Dependencies.sbtBackgroundRun)
+      version := Dependencies.echoPluginVersion,
+      aspectJVersion := Dependencies.aspectJVersion,
+      libraryDependencies ++= Seq(Dependencies.aspectjTools, Dependencies.sbtBackgroundRun),
+      sourceGenerators in Compile <+= buildInfo,
+      buildInfoKeys := Seq[BuildInfoKey](version, aspectJVersion),
+      buildInfoPackage := "com.typesafe.sbt.echoakka"
       )
     )
 
@@ -52,6 +62,7 @@ object SbtEchoBuild extends Build {
       settings (defaultSettings: _*)
       settings (Dependencies.playPlugin: _*)
       settings (
+      version := Dependencies.echoPluginVersion,
       name := "sbt-echo-play"
       )
     )

--- a/sbt-echo/akka/src/main/scala/com/typesafe/sbt/SbtEcho.scala
+++ b/sbt-echo/akka/src/main/scala/com/typesafe/sbt/SbtEcho.scala
@@ -12,8 +12,8 @@ import sbt.BackgroundJobServiceKeys
 object SbtEcho extends AutoPlugin {
   import echo.EchoRun._
 
-  val EchoVersion = "0.1.10"
-  val AspectjVersion = "1.8.4"
+  val EchoVersion = echoakka.BuildInfo.version
+  val AspectjVersion = echoakka.BuildInfo.aspectJVersion
 
   val Echo = config("echo").extend(Compile)
   val EchoTest = config("echo-test").extend(Echo, Test)


### PR DESCRIPTION
The intent here is that you can change the version in Dependencies.scala and then go into the echo and sbt-echo projects and publish those.
