### PR TITLE
Potential fix for the "hidden Play" problem

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   // this version is used to publish echo and sbt-echo,
   // and also to set which version of those Activator
   // depends on.
-  val echoVersion = "0.1.11"
+  val echoVersion = "0.1.12"
 
   val sbtVersion = "0.13.8-M3"
   val sbtLibraryVersion = "0.13.8-M3" // for sbtIO on scala 2.11
@@ -63,8 +63,8 @@ object Dependencies {
   val playSbt13Plugin        =  Defaults.sbtPluginExtra("com.typesafe.play" % "sbt-plugin" % play23Version, "0.13", "2.10")
   val eclipseSbt13Plugin     =  Defaults.sbtPluginExtra("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0", "0.13", "2.10")
   val ideaSbt13Plugin        =  Defaults.sbtPluginExtra("com.github.mpeltonen" % "sbt-idea" % "1.5.2", "0.13", "2.10")
-  val echoSbt13Plugin        =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo-play" % echoVersion, "0.13", "2.10")
-  val echoPlaySbt13Plugin    =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo" % echoVersion, "0.13", "2.10")
+  val echoSbt13Plugin        =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo" % echoVersion, "0.13", "2.10")
+  val echoPlaySbt13Plugin    =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo-play" % echoVersion, "0.13", "2.10")
 
   // Embedded databases / index
   val lucene = "org.apache.lucene" % "lucene-core" % luceneVersion
@@ -167,6 +167,8 @@ object Dependencies {
 
   // *** SBT-ECHO DEPENDENCIES ***
   val aspectjTools = "org.aspectj" % "aspectjtools" % aspectJVersion
+
+  val aspectjWeaver = "org.aspectj" % "aspectjweaver" % aspectJVersion
 
   val sbtBackgroundRun = Defaults.sbtPluginExtra("org.scala-sbt" % "sbt-core-next" % sbtCoreNextVersion, "0.13", "2.10")
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -30,7 +30,7 @@ object TheActivatorBuild extends Build {
       sys.props("activator.home") = fixFileForURIish(bd.getAbsoluteFile)
       bd
     }
-  ) 
+  )
   // TODO : Add ++ play.Project.intellijCommandSettings Play 2.3 style to settings above
 
   val root = (
@@ -218,13 +218,13 @@ object TheActivatorBuild extends Build {
         echoSbt13Plugin,
         echoPlaySbt13Plugin,
 
-        // featured template dependencies 
+        // featured template dependencies
         // *** note: do not use %% here ***
         "com.h2database" % "h2" % "1.3.170",
         "org.scalatest" % "scalatest_2.11" % "2.2.1",
         "com.typesafe.trace" % "echo-trace-akka-2.3.9_2.11" % Dependencies.echoVersion,
         "com.typesafe.trace" % "echo-sigar-libs" % Dependencies.echoVersion,
-        "org.aspectj" % "aspectjweaver" % Dependencies.aspectJVersion,
+        Dependencies.aspectjWeaver,
         "org.scala-lang" % "jline" % "2.10.4",
         "org.webjars" % "bootstrap" % "3.0.0",
         "org.webjars" % "knockout" % "2.3.0",

--- a/project/sbtEcho.scala
+++ b/project/sbtEcho.scala
@@ -49,7 +49,7 @@ object SbtEchoBuild extends Build {
       name := "sbt-echo",
       version := Dependencies.echoVersion,
       aspectJVersion := Dependencies.aspectJVersion,
-      libraryDependencies ++= Seq(Dependencies.aspectjTools, Dependencies.sbtBackgroundRun),
+      libraryDependencies += Dependencies.sbtBackgroundRun,
       sourceGenerators in Compile <+= buildInfo,
       buildInfoKeys := Seq[BuildInfoKey](version, aspectJVersion),
       buildInfoPackage := "com.typesafe.sbt.echoakka"

--- a/sbt-echo/play/src/main/scala/com/typesafe/sbt/echo/EchoPlayRun.scala
+++ b/sbt-echo/play/src/main/scala/com/typesafe/sbt/echo/EchoPlayRun.scala
@@ -7,7 +7,6 @@ package echo
 import sbt._
 import sbt.Keys._
 import play.Play.ClassLoaderCreator
-import org.aspectj.weaver.loadtime.WeavingURLClassLoader
 
 object EchoPlayRun {
   import EchoRun._


### PR DESCRIPTION
AspectJ's weaver and tools jar contain a top-level class 'Play' that
conflicts with sbt's automagical import of plugins on .sbt files that
use Typesafe Play.  As it turns out we don't need either one of these
artifacts if we do forked background run all the time.