### PR TITLE
Removed hard coded version from HTML

### DIFF
--- a/ui/app/assets/plugins/run/actors/actors.html
+++ b/ui/app/assets/plugins/run/actors/actors.html
@@ -117,7 +117,7 @@
   <!-- ko ifnot: actors().length -->
   <div class="hint actors">
     <p>You can see actor information here</p>
-    <span>So far there has been no activity in your application or you're running an unsupported version of Akka (&gt;2.3.4)</span>
+    <span>So far there has been no activity in your application or you're running an unsupported version of Akka.</span>
   </div>
   <!-- /ko -->
 


### PR DESCRIPTION
We will warn if someone tries to use Inspect on an unsupported version of Akka. Also, never a good idea to have hard coded version lingering about in the HTML...