### PR TITLE
Always use CrossVersion.binary for akka tracing

### DIFF
--- a/sbt-echo/akka/src/main/scala/com/typesafe/sbt/echo/EchoRun.scala
+++ b/sbt-echo/akka/src/main/scala/com/typesafe/sbt/echo/EchoRun.scala
@@ -84,15 +84,7 @@ object EchoRun {
     else version
 
   def traceAkkaDependencies(akkaVersion: String, echoVersion: String, scalaVersion: String): Seq[ModuleID] = {
-    val crossVersion = akkaCrossVersion(akkaVersion, scalaVersion)
-    Seq("com.typesafe.trace" % ("echo-trace-akka-" + stripBinVersion(akkaVersion)) % echoVersion % EchoTraceCompile.name cross crossVersion)
-  }
-
-  def akkaCrossVersion(akkaVersion: String, scalaVersion: String): CrossVersion = {
-    if (akkaVersion startsWith "2.0.") CrossVersion.Disabled
-    else if (akkaVersion startsWith "2.1.") CrossVersion.Disabled
-    else if (scalaVersion contains "-") CrossVersion.full
-    else CrossVersion.binary
+    Seq("com.typesafe.trace" % ("echo-trace-akka-" + stripBinVersion(akkaVersion)) % echoVersion % EchoTraceCompile.name cross CrossVersion.binary)
   }
 
   def weaveDependencies(version: String) = Seq(


### PR DESCRIPTION
akka 2.0 and 2.1 aren't used anymore, and the special-case
for a version with a "-" in it broke us on reactive platform.