### PR TITLE
Handle failure to load build during initial analysis

### DIFF
--- a/ui/app/assets/widgets/home/home.js
+++ b/ui/app/assets/widgets/home/home.js
@@ -18,51 +18,6 @@ define([
   modals
 ) {
 
-  var failedDueToNoTypesafeProperties = false;
-  var failedDueToNoSubscriptionId = false;
-
-  var sbtEventStream = websocket.subscribe('type','sbt');
-  var subTypeEventStream = function(subType) {
-    return sbtEventStream.matchOnAttribute('subType',subType);
-  };
-
-  subTypeEventStream("DetachedEvent").each(function(message) {
-    var event = message.event;
-
-    var name = event.serialized.$type;
-
-    if (name === "com.typesafe.rp.protocol.SubscriptionIdEvent") {
-      debug && console.log("SubscriptionIdEvent: ", event.serialized);
-      if (!event.serialized.fileExists)
-        failedDueToNoTypesafeProperties = true;
-      else if (!event.serialized.subscriptionId)
-        failedDueToNoSubscriptionId = true;
-    }
-  });
-
-  subTypeEventStream("BuildFailedToLoad").each(function (e) {
-    var warning = null;
-
-    if (failedDueToNoTypesafeProperties) {
-      warning = "If you are creating Typesafe Reactive Platform project you must add a '<code>typesafe.properties</code>' file in the '<code>&lt;template&gt;/project</code>' folder.</p><p>The file must contain your subscription ID in the format '<code>typesafe.subscription=&lt;YOUR ID&gt;</code>'<br/>To get a free trial subscription ID visit: <a href='https://typesafe.com/account/id' target='_blank'>https://typesafe.com/account/id</a><p>";
-    } else if (failedDueToNoSubscriptionId) {
-      warning = "If you are creating Typesafe Reactive Platform project, <code>project/typesafe.properties</code> must  contain your subscription ID in the format '<code>typesafe.subscription=&lt;YOUR ID&gt;</code>'<br/>To get a free trial subscription ID visit: <a href='https://typesafe.com/account/id' target='_blank'>https://typesafe.com/account/id</a><p>";
-    } else {
-      warning = "The build configuration for this project did not load correctly.";
-    }
-
-    var warningNode = $("<article/>").html(warning)[0];
-    modals.show({
-      shape: "large",
-      title: "Could not load project",
-      body: warningNode,
-      cancel: "Return",
-      onCancel: function() {
-        $('#working, #open, #new').toggle();
-      }
-    });
-  });
-
   var SharedState = {
     working: ko.observable(false)
   };

--- a/ui/app/assets/widgets/home/working/working.js
+++ b/ui/app/assets/widgets/home/working/working.js
@@ -3,10 +3,12 @@
  */
 define([
   'commons/websocket',
-  'text!./working.html'
+  'text!./working.html',
+  'widgets/modals/modals'
 ], function(
   websocket,
-  tpl
+  tpl,
+  modals
 ) {
 
   var logs = ko.observableArray([]);
@@ -22,9 +24,36 @@ define([
   var State = {
     logsView: logsView,
     scroll: scroll
-  }
+  };
 
-  websocket.subscribe({type: "sbt", subType: "DetachedLogEvent"}).fork().each(function(message) {
+  var failedDueToNoTypesafeProperties = false;
+  var failedDueToNoSubscriptionId = false;
+  var failedToLoad = false;
+
+  var sbtEventStream = websocket.subscribe('type','sbt');
+  var subTypeEventStream = function(subType) {
+    return sbtEventStream.matchOnAttribute('subType',subType);
+  };
+
+  subTypeEventStream("DetachedEvent").each(function(message) {
+    var event = message.event;
+
+    var name = event.serialized.$type;
+
+    if (name === "com.typesafe.rp.protocol.SubscriptionIdEvent") {
+      debug && console.log("SubscriptionIdEvent: ", event.serialized);
+      if (!event.serialized.fileExists)
+        failedDueToNoTypesafeProperties = true;
+      else if (!event.serialized.subscriptionId)
+        failedDueToNoSubscriptionId = true;
+    }
+  });
+
+  subTypeEventStream("BuildFailedToLoad").each(function (e) {
+    failedToLoad = true;
+  });
+
+  subTypeEventStream("DetachedLogEvent").fork().each(function(message) {
     if (message.event.entry.level !== "debug") {
       logs.push({
         message: message.event.entry.message,
@@ -33,13 +62,45 @@ define([
     }
   });
 
+  var redirect = function(appId) {
+    // NOTE - Comment this out if you want to debug showing logs!
+    window.location.href = window.location.href.replace('home', 'app/'+appId+'/');
+  };
+
+  var maybeWarnThenRedirect = function(appId) {
+    var warning = null;
+
+    if (failedDueToNoTypesafeProperties) {
+      warning = "If you are creating Typesafe Reactive Platform project you must add a '<code>typesafe.properties</code>' file in the '<code>&lt;template&gt;/project</code>' folder.</p><p>The file must contain your subscription ID in the format '<code>typesafe.subscription=&lt;YOUR ID&gt;</code>'<br/>To get a free trial subscription ID visit: <a href='https://typesafe.com/account/id' target='_blank'>https://typesafe.com/account/id</a><p>";
+    } else if (failedDueToNoSubscriptionId) {
+      warning = "If you are creating Typesafe Reactive Platform project, <code>project/typesafe.properties</code> must  contain your subscription ID in the format '<code>typesafe.subscription=&lt;YOUR ID&gt;</code>'<br/>To get a free trial subscription ID visit: <a href='https://typesafe.com/account/id' target='_blank'>https://typesafe.com/account/id</a><p>";
+    } else if (failedToLoad) {
+      warning = "The build configuration for this project did not load correctly.";
+    }
+
+    if (warning) {
+      var warningNode = $("<article/>").html(warning)[0];
+      modals.show({
+        shape: "large",
+        title: "Could not load build configuration",
+        body: warningNode,
+        cancel: "Proceed",
+        onCancel: function() {
+          redirect(appId);
+        }
+      });
+    } else {
+      redirect(appId);
+    }
+  };
+
   websocket.subscribe({ response: String }).fork().each(function(message) {
     switch(message.response) {
       case 'Status':
         logs.push({
           message: message.info,
           type: "info"
-        })
+        });
         break;
       case 'BadRequest':
         // TODO - Do better than an alert!
@@ -47,8 +108,7 @@ define([
         $('#working, #open, #new').toggle();
         break;
       case 'RedirectToApplication':
-        // NOTE - Comment this out if you want to debug showing logs!
-        window.location.href = window.location.href.replace('home', 'app/'+message.appId+'/');
+        maybeWarnThenRedirect(message.appId);
         break;
     }
   });
@@ -60,6 +120,6 @@ define([
 
       return dom;
     }
-  }
+  };
 
-})
+});


### PR DESCRIPTION
Before, we were throwing you back to /home which sucked.
Instead, pick a name based on the directory (we had code
for that if the project just lacked a name setting, already).
If the build fails, show a dialog and require clicking Proceed
before we open the app.