### PR TITLE
Only display 'mains' for non-play applications

### DIFF
--- a/ui/app/assets/plugins/run/run.html
+++ b/ui/app/assets/plugins/run/run.html
@@ -28,7 +28,7 @@
           </div>
           Run on build
         </li>
-        <!-- ko if: sbt.app.currentMainClass() -->
+        <!-- ko if: displayMains() -->
         <li>
           <h4>Main file</h4>
           <dl class="select dropdown">

--- a/ui/app/assets/plugins/run/run.js
+++ b/ui/app/assets/plugins/run/run.js
@@ -60,6 +60,10 @@ define([
     }
   });
 
+  var displayMains = ko.computed(function() {
+    return (sbt.tasks.applicationReady() && sbt.app.currentMainClass() && !sbt.tasks.isPlayApplication());
+  });
+
   var runDisabled = ko.computed(function() { return !runEnabled(); });
   var playUrl = sbt.tasks.playApplicationUrl;
   var displayPlayUrl = ko.computed(function() {
@@ -112,6 +116,7 @@ define([
     customCommands: sbt.app.customCommands,
     runEnabled: runEnabled,
     runDisabled: runDisabled,
+    displayMains: displayMains,
     displayPlayUrl: displayPlayUrl,
     playUrl: playUrl
   }


### PR DESCRIPTION
For now disabling showing alternative main methods for Play
applications.  In order to properly handle alternative mains a number of
UI changes need to happen:

* Start/stop main entry points independently
* Support passing arguments to main entry points
* Start/stop Play applications in addition to main entry points