### PR TITLE
Removes println

### DIFF
--- a/echo/trace/core/src/main/scala/com/typesafe/trace/send/ProtobufTraceSender.scala
+++ b/echo/trace/core/src/main/scala/com/typesafe/trace/send/ProtobufTraceSender.scala
@@ -11,9 +11,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 import java.util.concurrent.{ LinkedBlockingQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit }
 
 class ProtobufTraceSender(port: Int, capacity: Int, retry: Boolean, daemonic: Boolean, warn: Boolean, debug: Boolean) extends TraceSender {
-
-  println("Starting ProtobufTraceSender:")
-
+  
   val address = InetAddress.getByName(null)
 
   private val executor = {


### PR DESCRIPTION
We don't need to ship new versions of Echo/sbt-echo for this fix but the next time we do it's in there at least.