### PR TITLE
Makes echo and sbt-echo use the same version number as Activator.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,8 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  // this version is used to publish echo and sbt-echo,
-  // and also to set which version of those Activator
-  // depends on.
-  val echoVersion = "0.1.14"
+  // Used for plugins required by this build
+  val activatorStableVersion = "1.3.0"
 
   val sbtVersion = "0.13.8-M5"
   val sbtLibraryVersion = "0.13.8-M5" // for sbtIO on scala 2.11
@@ -63,8 +61,6 @@ object Dependencies {
   val playSbt13Plugin        =  Defaults.sbtPluginExtra("com.typesafe.play" % "sbt-plugin" % play23Version, "0.13", "2.10")
   val eclipseSbt13Plugin     =  Defaults.sbtPluginExtra("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0", "0.13", "2.10")
   val ideaSbt13Plugin        =  Defaults.sbtPluginExtra("com.github.mpeltonen" % "sbt-idea" % "1.5.2", "0.13", "2.10")
-  val echoSbt13Plugin        =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo" % echoVersion, "0.13", "2.10")
-  val echoPlaySbt13Plugin    =  Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo-play" % echoVersion, "0.13", "2.10")
 
   // Embedded databases / index
   val lucene = "org.apache.lucene" % "lucene-core" % luceneVersion

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -1,5 +1,4 @@
 import sbt._
-import Keys._
 
 object VersionGenerator {
   final val fileLocation = "/target/web/public/main/public/generated/dependencies.js"
@@ -19,7 +18,7 @@ object VersionGenerator {
          |],function (
          |) {
          |  var playVersion = "${Dependencies.play23Version}";
-         |  var echoVersion = "${Dependencies.echoVersion}";
+         |  var echoVersion = "${Dependencies.activatorStableVersion}";
          |  var ideaVersion = "${Dependencies.ideaVersion}";
          |  var eclipseVersion = "${Dependencies.eclipseVersion}";
          |  var sbtCoreNextVersion = "${Dependencies.sbtCoreNextVersion}";

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,17 +1,14 @@
-import org.apache.tools.ant.taskdefs.Echo
 import sbt._
 import ActivatorBuild._
-import EchoBuild._
 import Dependencies._
 import Packaging.localRepoArtifacts
 import com.typesafe.sbt.S3Plugin._
 import com.typesafe.sbt.SbtNativePackager.Universal
-import com.typesafe.sbt.SbtPgp
 import com.typesafe.sbt.SbtPgp.PgpKeys
 import play.PlayImport.PlayKeys
 import com.typesafe.sbt.less.Import.LessKeys
 import com.typesafe.sbt.web.SbtWeb.autoImport._
-import com.typesafe.sbt.jse.JsEngineImport.JsEngineKeys
+
 // NOTE - This file is only used for SBT 0.12.x, in 0.13.x we'll use build.sbt and scala libraries.
 // As such try to avoid putting stuff in here so we can see how good build.sbt is without build.scala.
 
@@ -38,7 +35,7 @@ object TheActivatorBuild extends Build {
     .noAutoPgp
     .doNotPublish
     aggregate(toReferences(publishedProjects ++
-      Seq(dist, it, localTemplateRepo, offlinetests)): _*)
+      Seq(dist, it, localTemplateRepo, offlinetests, EchoBuild.echo, SbtEchoBuild.sbtEcho)): _*)
   )
 
   lazy val news: Project = (
@@ -214,8 +211,8 @@ object TheActivatorBuild extends Build {
         playSbt13Plugin,
         eclipseSbt13Plugin,
         ideaSbt13Plugin,
-        echoSbt13Plugin,
-        echoPlaySbt13Plugin,
+        Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo" % activatorStableVersion, "0.13", "2.10"),
+        Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-echo-play" % activatorStableVersion, "0.13", "2.10"),
 
         // featured template dependencies
         // *** note: do not use %% here ***

--- a/project/echo.scala
+++ b/project/echo.scala
@@ -18,8 +18,7 @@ object EchoBuild extends Build {
       settings (LocalTemplateRepo.settings: _*)
       settings(
       Keys.resolvers += typesafeIvyReleases,
-      parallelExecution in GlobalScope := false,
-      version := Dependencies.echoVersion
+      parallelExecution in GlobalScope := false
       )
       aggregate(trace, collect, collect211, sigarLibs)
     )
@@ -27,7 +26,6 @@ object EchoBuild extends Build {
   lazy val trace = (
     Project("echo-trace", file("echo/trace"))
       .doNotPublish
-      settings(version := Dependencies.echoVersion)
       aggregate(
       protocolProtobuf24, protocolProtobuf25,
       event210Protobuf24, event210Protobuf25,
@@ -45,7 +43,6 @@ object EchoBuild extends Build {
     (Project("echo-sigar-libs", file("echo/sigar"))
       settings (defaultSettings: _*)
       settings(
-      version := Dependencies.echoVersion,
       resourceDirectory in Compile <<= baseDirectory / "lib",
       autoScalaLibrary := false,
       pomIncludeRepository := { _ => false},
@@ -78,7 +75,6 @@ object EchoBuild extends Build {
   )
 
   lazy val projectSettings = buildSettings ++ Seq(
-    version := Dependencies.echoVersion,
     resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
     // compile options
     scalacOptions <++= scalaVersion map { sv =>
@@ -377,7 +373,6 @@ object CollectProjects extends Build {
       .doNotPublish
       dependsOn (event210Protobuf24)
       settings(
-      version := Dependencies.echoVersion,
       sbt.Keys.scalaVersion := Dependencies.scala210Version,
       libraryDependencies ++= Seq(akkaSlf4j22, slf4j, logback, akkaTestKit22, scalaTest, junit)
       )

--- a/project/sbtEcho.scala
+++ b/project/sbtEcho.scala
@@ -12,7 +12,6 @@ object SbtEchoBuild extends Build {
     Project("sbt-echo", base = file("sbt-echo"))
       settings (noPublishSettings: _*)
       settings (defaultSettings: _*)
-      settings (version := Dependencies.echoVersion)
       aggregate(sbtEchoAkka, sbtEchoPlay)
     )
 
@@ -47,7 +46,6 @@ object SbtEchoBuild extends Build {
       settings (buildInfoSettings: _*)
       settings(
       name := "sbt-echo",
-      version := Dependencies.echoVersion,
       aspectJVersion := Dependencies.aspectJVersion,
       libraryDependencies += Dependencies.sbtBackgroundRun,
       sourceGenerators in Compile <+= buildInfo,
@@ -62,7 +60,6 @@ object SbtEchoBuild extends Build {
       settings (defaultSettings: _*)
       settings (Dependencies.playPlugin: _*)
       settings (
-      version := Dependencies.echoVersion,
       name := "sbt-echo-play"
       )
     )


### PR DESCRIPTION
Stab at using the same version for ``Echo`` and ``sbtEcho`` as ``Activator``. Introduces a ``activatorStableBuild`` variable to use for the plugin references, but I am not sure if this is the way we want to roll? Suggestions are welcome.  