### PR TITLE
Lengthen timeout for template cache operations

### DIFF
--- a/ui-common/src/main/scala/activator/UICacheHelper.scala
+++ b/ui-common/src/main/scala/activator/UICacheHelper.scala
@@ -13,9 +13,14 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorSystem
 import akka.actor.ActorContext
 import akka.event.LoggingAdapter
+import scala.concurrent.duration._
 
 // This helper constructs the template cache in the default CLI/UI location.
 object UICacheHelper {
+
+  // this is intended to be close to "forever" since if we time
+  // out we'll pretty much fail catastrophically
+  private implicit val timeout = akka.util.Timeout(Duration(240, SECONDS))
 
   // TODO - Config or ActiavtorProperties?
   lazy val config = ConfigFactory.load()
@@ -30,7 +35,7 @@ object UICacheHelper {
 
   val localSeed = Option(ActivatorProperties.ACTIVATOR_TEMPLATE_LOCAL_REPO) map (new File(_)) filter (_.isDirectory)
 
-  def makeDefaultCache(actorFactory: ActorRefFactory)(implicit timeout: akka.util.Timeout): TemplateCache = {
+  def makeDefaultCache(actorFactory: ActorRefFactory): TemplateCache = {
     DefaultTemplateCache(
       actorFactory = actorFactory,
       location = localCache,
@@ -38,7 +43,7 @@ object UICacheHelper {
       seedRepository = localSeed)
   }
 
-  def makeLocalOnlyCache(actorFactory: ActorRefFactory)(implicit timeout: akka.util.Timeout): TemplateCache = {
+  def makeLocalOnlyCache(actorFactory: ActorRefFactory): TemplateCache = {
     DefaultTemplateCache(
       actorFactory = actorFactory,
       location = localCache,

--- a/ui/app/controllers/api/Templates.scala
+++ b/ui/app/controllers/api/Templates.scala
@@ -9,15 +9,10 @@ import play.api.libs.json._
 import play.filters.csrf._
 import activator._
 import activator.cache.TemplateMetadata
-import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 object Templates extends Controller {
-  // This will load our template cache and ensure all templates are available for the demo.
-  // We should think of an alternative means of loading this in the future.
-  // TODO - We should load timeout from configuration.
-  implicit val timeout = akka.util.Timeout(Duration(12, SECONDS))
   val templateCache = activator.UICacheHelper.makeDefaultCache(snap.Akka.system)
 
   // Here's the JSON rendering of template metadata.


### PR DESCRIPTION
Moved it to 4 minutes from 12 seconds, so only truly stuck operations should
time out. We don't want to fail just because of a slow network.