### PR TITLE
Added support to retry "not a subscriber" case

### DIFF
--- a/ui/app/activator/typesafeproxy/Models.scala
+++ b/ui/app/activator/typesafeproxy/Models.scala
@@ -10,16 +10,16 @@ sealed trait SubscriptionLevel {
 }
 object SubscriptionLevels {
   sealed abstract class NamedSubscription(override val name: String) extends SubscriptionLevel
-  case object Developer extends NamedSubscription("developer")
-  case object Production extends NamedSubscription("production")
-  case object TwentyFourSeven extends NamedSubscription("twentyFourSeven")
+  case object Developer extends NamedSubscription("developerSubscriber")
+  case object Production extends NamedSubscription("productionSubscriber")
+  case object TwentyFourSeven extends NamedSubscription("twentyFourSevenSubscriber")
 
   val subscriptionLevelReads: Reads[SubscriptionLevel] = new Reads[SubscriptionLevel] {
     def reads(in: JsValue): JsResult[SubscriptionLevel] = in match {
       case JsString(Developer.name) => JsSuccess(Developer)
       case JsString(Production.name) => JsSuccess(Production)
       case JsString(TwentyFourSeven.name) => JsSuccess(TwentyFourSeven)
-      case v => JsError(s"Expected one of 'developer', 'production', or 'twentyFourSeven' got: $v")
+      case v => JsError(s"Expected one of 'developerSubscriber', 'productionSubscriber', or 'twentyFourSevenSubscriber' got: $v")
     }
   }
 
@@ -58,8 +58,8 @@ object SubscriberData {
   val subscriberDataReads: Reads[SubscriberData] = new Reads[SubscriberData] {
     def reads(in: JsValue): JsResult[SubscriberData] = {
       val id = Json.fromJson[String](in \ "id").asOpt
-      val subscription = Json.fromJson[Option[SubscriptionLevel]](in \ "subscription").asOpt
-      val isPaidSubscriber = Json.fromJson[Boolean](in \ "isPaidSubscriber").asOpt
+      val subscription = Json.fromJson[Option[SubscriptionLevel]](in \ "primarySubscriberRole").asOpt
+      val isPaidSubscriber = Json.fromJson[Boolean](in \ "isSubscriber").asOpt
       val acceptedDate = Json.fromJson[Option[DateTime]](in \ "acceptedDate").asOpt
       val majorVersion = Json.fromJson[String](in \ "majorVersion").asOpt
       val currentReleaseVersion = Json.fromJson[String](in \ "currentReleaseVersion").asOpt
@@ -78,7 +78,7 @@ object SubscriberData {
     def writes(in: SubscriberData): JsValue = in match {
       case NotASubscriber(m) => Json.obj("message" -> m)
       case Detail(id, s, ips, ad, mv, crv) => Json.obj("id" -> id,
-        "subscription" -> s,
+        "primarySubscriberRole" -> s,
         "isPaidSubscriber" -> ips,
         "acceptedDate" -> ad,
         "majorVersion" -> mv,

--- a/ui/app/assets/services/sbt/tasks.js
+++ b/ui/app/assets/services/sbt/tasks.js
@@ -86,6 +86,7 @@ define([
       self.installedMajorVersion(null);
       self.fullUpdate(false);
       self.majorUpdate(false);
+      self.typesafeId("");
       self.isReactivePlatformProject(false);
       self.typesafeIdFormVisible(false);
     };

--- a/ui/app/assets/services/typesafe.js
+++ b/ui/app/assets/services/typesafe.js
@@ -93,10 +93,14 @@ define([
     websocket.send(request);
   }
 
-  function getSubscriptionDetail() {
+  function getSubscriptionDetail(subscriptionFunc) {
     var id = pseudoUniqueId();
     var response = ko.observable();
+    response.subscribe(subscriptionFunc);
     var subs = websocket.subscribe('tag','TypesafeComProxy');
+    response.subscribe(function(newValue) {
+      subs.close();
+    });
     proxyRequest("getSubscriptionDetail",{requestId: id});
     subs.each(function(message) {
       var type = message.type;
@@ -116,9 +120,6 @@ define([
       }
     });
 
-    response.subscribe(function(newValue) {
-      subs.close();
-    });
     return response;
   }
 

--- a/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.html
+++ b/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.html
@@ -8,6 +8,7 @@
       <p>You can retrieve your ID, or sign up for a free trial, on the <a href='https://typesafe.com/product/typesafe-reactive-platform/id' target='_blank'>subscription ID page</a> page.</p>
       <div class="input-wrapper"><div data-bind="css: typesafeIdStateClass"></div><input class='typesafeId-form' type='text' data-bind="textInput: typesafeId" /></div>
       <p class='typesafe-id-error' data-bind='visible: errorVisible, html: typesafeIdError'></p>
+      <p class='typesafe-id-error' data-bind='visible: notASubscriber'>Your account does not have a Typesafe subscription.  You may wish to try another account.</p>
       <!-- ko if: continueVisible -->
       <p class='get-from-typesafe'><button class='from-typesafe-button' data-bind="click: checkId">Continue</button></p>
       <!-- /ko -->

--- a/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.js
+++ b/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.js
@@ -17,6 +17,7 @@ define([
   var FormState = (function(){
     var self = {};
     self.dummyRecompute = ko.observable(1);
+    self.notASubscriber = ko.observable(false);
     self.forceIdCheck = function () {
       var x = self.dummyRecompute();
       self.dummyRecompute(x + 1);
@@ -28,10 +29,11 @@ define([
       return (id && (id.length === 36));
     });
     self.getIDFromTypesafeCom = function() {
-      var obs = typesafe.getSubscriptionDetail();
-      obs.subscribe(function (v) {
+      typesafe.getSubscriptionDetail(function (v) {
         if (v.type === "subscriptionDetails") {
           self.typesafeId(v.data.id);
+        } else if (v.type === "notASubscriber") {
+          self.notASubscriber(true);
         }
       });
     };

--- a/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.less
+++ b/ui/app/assets/widgets/typesafeIdForm/typesafeIdForm.less
@@ -45,6 +45,10 @@
     height: 18px;
   }
 
+  .typesafe-id-error {
+    color: red;
+  }
+
   .checking-id {
     background: url(/assets/icons/working-blue.svg) center center no-repeat;
     .spin();

--- a/ui/app/controllers/Application.scala
+++ b/ui/app/controllers/Application.scala
@@ -332,7 +332,7 @@ object Application extends Controller {
   val initState = TypesafeComProxy.initialStateBuilder(authGetter = (_, v, r, w) => AuthenticationActor.props(loginEndpoint, UIActor.props, v, r, w),
     subscriberDataGetter = (_, v, r, w) => SubscriptionDataActor.props(subscriberEndpoint, UIActor.props, v, r, w),
     activatorInfoGetter = (_, v, r, w) => ActivatorLatestActor.props(activatorInfoEndpoint, UIActor.props, v, r, w),
-    httpJsonGetter = (req, v, r, w) => JsonGetterActor.props(req.url, httpJsonGetter, req.toPut, UIActor.props, v, r, w))
+    httpJsonGetter = (req, v, r, w) => JsonGetterActor.props(req.url, httpJsonGetter, req.toPut(_, _, _, true), UIActor.props, v, r, w))
   val typesafeComActor = activator.Akka.system.actorOf(TypesafeComProxy.props(initialCacheState = initState))
 
   /** Opens a stream for home events. */


### PR DESCRIPTION
* "Not a subscriber" is now indicated in the UI
* You can try another account 
* Fixed parsing Typesafe.com response for subscription API (changed upstream)
* Fixed two possible race conditions in JS.