### PR TITLE
isLocal is a boolean, not a function; fixes #1029

### DIFF
--- a/ui/app/assets/plugins/tutorial/tutorial.html
+++ b/ui/app/assets/plugins/tutorial/tutorial.html
@@ -58,7 +58,7 @@
         <div class="description">
           <h1>Tutorial</h1>
           <p>No descrption for this tutorial.</p>
-          <!-- ko if: isLocal() -->
+          <!-- ko if: isLocal -->
             <p>Please note that descriptions are loaded from Typesafe server, hence are not available in local tutorial development</p>
           <!-- /ko -->
         </div>


### PR DESCRIPTION
Confirmed fix in my local staged version of Activator.