### PR TITLE
Minor corrections for Windows startup script

### DIFF
--- a/dist/src/templates/activator.bat
+++ b/dist/src/templates/activator.bat
@@ -52,7 +52,7 @@ rem Detect if we were double clicked, although theoretically A user could
 rem manually run cmd /c
 for %%x in (%cmdcmdline%) do if %%~x==/c set DOUBLECLICKED=1
 
-set SBT_HOME=%BIN_DIRECTORY
+set SBT_HOME=%BIN_DIRECTORY%
 
 rem Detect if we were double clicked, although theoretically A user could
 rem manually run cmd /c
@@ -98,7 +98,7 @@ if "%_JAVACMD%"=="" (
     if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
 
     rem if there is a java home set we make sure it is the first picked up when invoking 'java'
-    SET "PATH=%JAVA_HOME%\bin;%PATH%"
+    SET PATH="%JAVA_HOME%\bin";%PATH%
   )
 )
 


### PR DESCRIPTION
- Added missing trailing `%`
- Allow `%PATH%` and `%JAVA_HOME%` to contain `"` or spaces.