### PR TITLE
Fixed activator batch script startup issues (replaces #1124)

### DIFF
--- a/dist/src/templates/activator.bat
+++ b/dist/src/templates/activator.bat
@@ -39,7 +39,7 @@ if defined var1 (
 @REM determine ACTIVATOR_HOME environment variable
 set BIN_DIRECTORY=%~dp0
 set BIN_DIRECTORY=%BIN_DIRECTORY:~0,-1%
-for %%d in (%BIN_DIRECTORY%) do set ACTIVATOR_HOME=%%~dpd
+for %%d in ("%BIN_DIRECTORY%") do set ACTIVATOR_HOME=%%~dpd
 set ACTIVATOR_HOME=%ACTIVATOR_HOME:~0,-1%
 
 echo ACTIVATOR_HOME=%ACTIVATOR_HOME%
@@ -98,7 +98,7 @@ if "%_JAVACMD%"=="" (
     if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
 
     rem if there is a java home set we make sure it is the first picked up when invoking 'java'
-    SET PATH="%JAVA_HOME%\bin";%PATH%
+    SET PATH="%JAVA_HOME%\bin";"%PATH%"
   )
 )
 

--- a/dist/src/templates/activator.bat
+++ b/dist/src/templates/activator.bat
@@ -98,7 +98,7 @@ if "%_JAVACMD%"=="" (
     if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
 
     rem if there is a java home set we make sure it is the first picked up when invoking 'java'
-    SET PATH="%JAVA_HOME%\bin";"%PATH%"
+    SET "PATH=%JAVA_HOME%\bin;%PATH%"
   )
 )
 


### PR DESCRIPTION
Replaces #1124 

# What

This merge will apply fixes to windows batch startup script **activator.bat**

# Problem

When launching on **Windows x64** platforms in case if the path to **Activator** distributive contains spaces, the following error appeared:
```cmd
\Lightbend\Activator\bin) was unexpected at this time.
```

# Testing

The fixes were checked on the following environment:

* Windows 10 x64
* ACTIVATOR_HOME=C:\Program Files (x86)\Lightbend\Activator
* PATH=<...>;%ACTIVATOR_HOME%\bin


