### PR TITLE
Fix .sbtopts isn't read from activator.bat #1128

### DIFF
--- a/dist/src/templates/activator.bat
+++ b/dist/src/templates/activator.bat
@@ -68,6 +68,20 @@ FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%FN%") DO (
   set CFG_OPTS=!CFG_OPTS! !DO_NOT_REUSE_ME!
 )
 
+rem FIRST we load a project-level config file of extra options (if there is one)
+set "SBT_OPTS_FILE=.sbtopts"
+  if exist %SBT_OPTS_FILE% (
+    FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%SBT_OPTS_FILE%") DO (
+      set DO_NOT_REUSE_ME=%%i
+      rem ZOMG (Part #2) WE use !! here to delay the expansion of
+      rem CFG_OPTS, otherwise it remains "" for this loop.
+    	if "!DO_NOT_REUSE_ME:~0,2!"=="-J" (
+          set CFG_OPTS=!CFG_OPTS! !DO_NOT_REUSE_ME:~2!
+    	)
+    )
+  )
+)
+
 rem FIRST we load a config file of extra options (if there is one)
 set "CFG_FILE_HOME=%UserProfile%\.activator\activatorconfig.txt"
 set "CFG_FILE_VERSION=%UserProfile%\.activator\%APP_VERSION%\activatorconfig.txt"


### PR DESCRIPTION
`activator.bat` was changed to be able to set JVM parameters from `.sbtopts`.

I tested this patch by a process:

1. Start [lagom-java-chirper]() by `activator runAll`
2. Checked JVM parameters on the process with `jinfo`

* `.sbtopts`

    ```
    -J-Xms512M
    -J-Xmx4096M
    -J-Xss2M
    -J-XX:MaxMetaspaceSize=1024M
    ```

* current version (1.3.10)

    ```
    VM Flags:
Non-default VM flags: -XX:CICompilerCount=3 -XX:InitialHeapSize=268435456 -XX:MaxHeapSize=4271898624 -XX:MaxMetaspaceSize=268435456 -XX:MaxNewSize=1423966208 -XX:MetaspaceSize=67108864 -XX:MinHeapDeltaBytes=524288 -XX:NewSize=89128960 -XX:OldSize=179306496 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseFastUnorderedTimeStamps -XX:-UseLargePagesIndividualAllocation -XX:+UseParallelGC 
Command line:  -XX:MetaspaceSize=64M -XX:MaxMetaspaceSize=256M -Dactivator.home=//C:/Apps/activator
    ```

* patched version

    ```
    VM Flags:
    Non-default VM flags: -XX:CICompilerCount=3 -XX:InitialHeapSize=536870912 -XX:MaxHeapSize=4294967296 -XX:MaxMetaspaceSize=1073741824 -XX:MaxNewSize=1431306240 -XX:MetaspaceSize=67108864 -XX:MinHeapDeltaBytes=524288 -XX:NewSize=178782208 -XX:OldSize=358088704 -XX:ThreadStackSize=2048 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseFastUnorderedTimeStamps -XX:-UseLargePagesIndividualAllocation -XX:+UseParallelGC 
Command line:  -XX:MetaspaceSize=64M -XX:MaxMetaspaceSize=256M -Xms512M -Xmx4096M -Xss2M -XX:MaxMetaspaceSize=1024M -Dactivator.home=//C:/Apps/activator
    ```
    ⇒  JVM parameters enabled: `-Xms512M -Xmx4096M -Xss2M -XX:MaxMetaspaceSize=1024M`