### PR TITLE
fixed escape sequence problem with windows location-paths

### DIFF
--- a/ui/app/views/home.scala.html
+++ b/ui/app/views/home.scala.html
@@ -23,7 +23,7 @@
       ];
       var recentApps = [
         @Html(model.recentApps.sortBy(_.usedTime).map { app =>
-          "{ id: '"+app.id+"', url: '"+routes.Application.app(app.id)+"', name: '"+app.cachedName.getOrElse(app.id)+"', location: '"+app.location+"' }"
+          "{ id: '"+app.id+"', url: '"+routes.Application.app(app.id)+"', name: '"+app.cachedName.getOrElse(app.id)+"', location: '"+JsString(app.location.getAbsolutePath()).toString()+"' }"
         }.mkString(","))
       ]
       var templates = @Html(json.toString);


### PR DESCRIPTION

 concering running activator ui on windows

 activator did start properly but displayed nothing but the background image in the browser
 because of `recentApps` var containing unescaped backslashes like (eg. '\u')